### PR TITLE
Fix config path for Navidrome (use /etc/ instead of /var/lib)

### DIFF
--- a/frontend/public/json/navidrome.json
+++ b/frontend/public/json/navidrome.json
@@ -33,7 +33,7 @@
     },
     "notes": [
         {
-            "text": "To change Navidrome music folder path, `nano /var/lib/navidrome/navidrome.toml`",
+            "text": "To change Navidrome music folder path, `nano /etc/navidrome/navidrome.toml`",
             "type": "info"
         }
     ]

--- a/frontend/public/json/navidrome.json
+++ b/frontend/public/json/navidrome.json
@@ -12,7 +12,7 @@
     "documentation": null,
     "website": "https://www.navidrome.org/",
     "logo": "https://raw.githubusercontent.com/selfhst/icons/refs/heads/main/svg/navidrome.svg",
-    "config_path": "/var/lib/navidrome/navidrome.toml",
+    "config_path": "/etc/navidrome/navidrome.toml",
     "description": "Navidrome is a music server solution that makes your music collection accessible from anywhere. It provides a modern web-based user interface and compatibility with a range of third-party mobile apps for both iOS and Android devices. With Navidrome, users can access their music collection from anywhere, whether at home or on the go. The software supports a variety of music formats, making it easy for users to play their favorite songs and albums. Navidrome provides a simple and user-friendly interface for managing and organizing music collections, making it a valuable tool for music lovers who want to access their music from anywhere. The software is designed to be easy to set up and use, making it a popular choice for those who want to host their own music server and enjoy their music collection from anywhere.",
     "install_methods": [
         {


### PR DESCRIPTION
The default systemd service loads `/etc/navidrome/navidrome.toml` via `-c`. Therefore, changes to `/var/lib/navidrome/navidrome.toml` have no effect unless manually specified.

This PR updates the web UI JSON entry to reflect the correct config file path.

Thanks for the great scripts!

## ✍️ Description  

Fixes misleading config path in the Navidrome JSON metadata shown on the website.  
This improves clarity for users editing their container config.

## 🔗 Related PR / Issue  
Link: *none*

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  